### PR TITLE
uploaderのバケットprivate化

### DIFF
--- a/app/api/uploadImage/routes.ts
+++ b/app/api/uploadImage/routes.ts
@@ -1,0 +1,64 @@
+// app/api/uploadImage/route.ts
+import { NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { auth } from '@clerk/nextjs/server'
+
+export const runtime = 'edge'
+
+export async function POST(request: Request) {
+  try {
+    // Clerk で認証したユーザーを取得 (auth() は Promise を返すので await が必要)
+    const { userId } = await auth()
+    if (!userId) {
+      return NextResponse.json({ error: '認証が必要です' }, { status: 401 })
+    }
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      { global: { headers: {} } }
+    )
+
+    // multipart/form-data を想定
+    const formData = await request.formData()
+    const file = formData.get('file') as File | null
+    if (!file) {
+      return NextResponse.json({ error: 'ファイルが送信されていません' }, { status: 400 })
+    }
+
+    // ファイルサイズ制限: 5MB
+    const maxSize = 5 * 1024 * 1024
+    if (file.size > maxSize) {
+      return NextResponse.json({ error: 'ファイルサイズは5MB以内にしてください' }, { status: 413 })
+    }
+
+    // 一般的な拡張子チェック
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp']
+    if (!allowedTypes.includes(file.type)) {
+      return NextResponse.json({ error: 'JPEG/PNG/WebP形式の画像をアップロードしてください' }, { status: 415 })
+    }
+
+    // 一意のパス生成
+    const ext = file.name.split('.').pop()
+    const fileName = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}.${ext}`
+    const filePath = `${userId}/${fileName}`
+
+    // Storage にアップロード
+    const { data, error } = await supabase.storage
+      .from('i-like')
+      .upload(filePath, file, { cacheControl: '3600', upsert: false })
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    // 公開 URL を生成
+    const { data: urlData } = supabase.storage
+      .from('i-like')
+      .getPublicUrl(data.path)
+
+    return NextResponse.json({ publicUrl: urlData.publicUrl })
+  } catch (e) {
+    return NextResponse.json({ error: 'サーバーエラーが発生しました' }, { status: 500 })
+  }
+}

--- a/components/component/profiles/ProfileEditForm.tsx
+++ b/components/component/profiles/ProfileEditForm.tsx
@@ -1,34 +1,30 @@
 // components/component/profiles/ProfileEditForm.tsx
 "use client";
 
-import { useState, useCallback, useRef, useTransition, FormEvent } from "react";
+import { useState, useCallback, useTransition, FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import type { User } from "@prisma/client"; // Prisma の User 型を使う（または必要なフィールドだけの型）
-import type { ActionResult } from "@/lib/types";
-import { useImageUploader } from "@/components/hooks/useImageUploader"; // 画像アップロードフック
+import type { User } from "@prisma/client";
+import { useImageUploader } from "@/components/hooks/useImageUploader";
 import {
   updateProfileAction,
   type ProfileUpdateData,
 } from "@/lib/actions/userActons";
 import { useToast } from "@/components/hooks/use-toast";
-import ImageUploader from "../common/ImageUploader"; // 画像アップローダーUIコンポーネント
+import ImageUploader from "../common/ImageUploader"; // 
 import {
   Card,
   CardHeader,
   CardTitle,
-  CardDescription,
   CardContent,
-} from "@/components/ui/card"; // Card関連
+} from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "@/components/component/Icons";
-import { z } from "zod"; // バリデーション用
+import { z } from "zod"; // 
 
-// --- Props の型定義 ---
-// 編集に必要なユーザーデータの部分型を定義
-// (lib/types.ts に UserProfileEditableData のような型を定義してインポートするのが望ましい)
+// 編集に必要なユーザーデータの部分型
 type InitialProfileData = Pick<
   User,
   | "name"

--- a/components/hooks/useImageUploader.ts
+++ b/components/hooks/useImageUploader.ts
@@ -1,104 +1,48 @@
 // hooks/useImageUploader.ts
-"use client";
+'use client'
 
-import { useState, useCallback } from 'react';
-// ★ createClient を @supabase/supabase-js から直接インポート ★
-import { createClient } from '@supabase/supabase-js';
-// ★ useUser と useSession をインポート ★
-import { useUser, useSession } from "@clerk/nextjs";
-import { useToast } from "@/components/hooks/use-toast";
-
-const BUCKET_NAME = 'i-like'; // ★ バケット名を再確認 ★
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+import { useState, useCallback } from 'react'
+import { useUser } from '@clerk/nextjs'
+import { useToast } from '@/components/hooks/use-toast'
 
 export function useImageUploader() {
-  const { user } = useUser();
-  const { session } = useSession(); // ★ useSession を使ってセッションを取得 ★
-  const { toast } = useToast();
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { user } = useUser()
+  const { toast } = useToast()
+  const [isLoading, setIsLoading] = useState(false)
 
   const uploadImage = useCallback(async (file: File): Promise<string | null> => {
-    setIsLoading(true);
-    setError(null);
-
-    // 環境変数とユーザーセッションのチェック
-    if (!supabaseUrl || !supabaseAnonKey) {
-      const msg = "Supabase の設定が環境変数にありません。";
-      setError(msg); toast({ title: "設定エラー", description: msg, variant: "destructive" });
-      setIsLoading(false); return null;
+    if (!user) {
+      toast({ title: '認証エラー', description: 'ユーザー情報が取得できません', variant: 'destructive' })
+      return null
     }
-    if (!user?.id) { /* ... */ return null; }
-    if (!session) { // ★ セッションが存在するかチェック ★
-      const msg = "Clerk セッションが見つかりません。";
-      setError(msg); toast({ title: "認証エラー", description: msg, variant: "destructive" });
-      setIsLoading(false); return null;
-    }
-    if (!file) { /* ... */ return null; }
-    if (!file.type.startsWith('image/')) { /* ... */ return null; }
 
-    const fileExt = file.name.split('.').pop()?.toLowerCase();
-    const timestamp = Date.now();
-    const randomSuffix = Math.random().toString(36).substring(2, 8);
-    const uniqueFileName = `${timestamp}_${randomSuffix}.${fileExt}`;
-    const filePath = `${user.id}/${uniqueFileName}`;
-
+    setIsLoading(true)
     try {
-      // ★★★ Clerk セッションを使って Supabase クライアントを作成 ★★★
-      console.log("Creating Supabase client with Clerk session token...");
-      const supabaseAccessToken = await session.getToken({ template: "supabase" }); // ★ useSession から getToken ★
-      if (!supabaseAccessToken) { throw new Error("Supabase アクセストークンを取得できませんでした。"); }
+      const form = new FormData()
+      form.append('file', file)
+      form.append('userId', user.id)
 
-      // ★ createClient に accessToken を渡す (または global headers) ★
-      //    ドキュメントの例に近いのは accessToken オプションだが、supabase-js v2 の推奨は headers かもしれない
-      //    まずはドキュメント例に合わせて accessToken オプションを試す
-      const supabase = createClient(
-        supabaseUrl,
-        supabaseAnonKey,
-        {
-          global: { // global オプションを使う方が一般的かもしれない
-            headers: { Authorization: `Bearer ${supabaseAccessToken}` }
-          },
-          // auth: { // このオプションは setSession を内部で呼ぶかもしれないので避ける方が安全か
-          //   autoRefreshToken: false,
-          //   persistSession: false,
-          //   detectSessionInUrl: false
-          // }
-        }
-      );
-      console.log("Supabase client initialized for upload.");
-      // ★★★ 以前の supabase.auth.setSession は削除 ★★★
+      const res = await fetch('/api/uploadImage', {
+        method: 'POST',
+        body: form,
+      })
+      const json = await res.json()
+      if (!res.ok) {
+        throw new Error(json.error || 'アップロードに失敗しました')
+      }
 
-      console.log(`Attempting to upload to Supabase Storage: ${filePath}`);
-      const { data, error: uploadError } = await supabase.storage
-        .from(BUCKET_NAME)
-        .upload(filePath, file, { cacheControl: '3600', upsert: false });
-
-      if (uploadError) { throw uploadError; }
-      console.log("Upload successful, data:", data);
-
-      // 公開 URL を取得 (これは通常のクライアントでも可能)
-      const { data: publicUrlData } = createClient(supabaseUrl, supabaseAnonKey).storage // 公開URL取得用に別クライアント作成
-          .from(BUCKET_NAME)
-          .getPublicUrl(data.path);
-
-      if (!publicUrlData?.publicUrl) { throw new Error("Failed to get public URL"); }
-      console.log("Public URL generated:", publicUrlData.publicUrl);
-
-      setIsLoading(false);
-      return publicUrlData.publicUrl;
-
+      return json.publicUrl as string
     } catch (err) {
-      console.error("Error uploading image:", err);
-      const message = err instanceof Error ? err.message : "アップロード中に不明なエラーが発生しました。";
-      setError(message);
-      toast({ title: "アップロードエラー", description: message, variant: "destructive" });
-      setIsLoading(false);
-      return null;
+      toast({
+        title: 'アップロードエラー',
+        description: err instanceof Error ? err.message : '不明なエラー',
+        variant: 'destructive',
+      })
+      return null
+    } finally {
+      setIsLoading(false)
     }
-  // ★ 依存配列に session を追加 ★
-  }, [user, toast, session]);
+  }, [user, toast])
 
-  return { uploadImage, isLoading, error };
+  return { uploadImage, isLoading }
 }


### PR DESCRIPTION
feat: 画像アップロードをPrivateバケット対応のAPI経由に移行

- app/api/uploadImage/route.ts を追加  
  - Clerk の認証チェック後、Service Role Key で Private バケットへアップロード  
  - 5MB 上限・JPEG/PNG/WebP 制限をサーバー側で適用  
  - アップロード後に公開 URL を返却  

- hooks/useImageUploader.ts を更新  
  - Supabase 直打ちから FormData 経由で新 API ルートを呼び出す方式に変更  
  - 認証エラー／アップロード失敗時はトースト通知  
