### PR TITLE
平均順位の集計ロジック変更

### DIFF
--- a/app/trends/average/[subject]/page.tsx
+++ b/app/trends/average/[subject]/page.tsx
@@ -1,5 +1,4 @@
 // app/trends/average/[subject]/page.tsx
-//サーバー上で URL から「何のテーマ」のリクエストかをデコードして取得し、見出しと、テーマ名を渡した子コンポーネントを描画し、子コンポーネント側で初めてクライアント（ブラウザ）でデータを取りにいって表示
 import AverageItemRankList from "@/components/component/trends/AverageItemRankList";
 
 interface PageProps {
@@ -8,16 +7,16 @@ interface PageProps {
 
 export default async function SubjectAveragePage({ params }: PageProps) {
   const { subject: rawSubject } = await params;
-
-  // URL エンコードされているかもしれないのでデコード
   const subject = Array.isArray(rawSubject)
-    ? decodeURIComponent(rawSubject[0]) // 配列なら最初の要素を取り出す
-    : decodeURIComponent(rawSubject); // 文字列ならそのまま使う
+    ? decodeURIComponent(rawSubject[0])
+    : decodeURIComponent(rawSubject);
 
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">「{subject}」のランキング集計</h1>
-      <h3 className="text-lg mb-4">集計結果は毎日0時に更新されます</h3>
+      <h1 className="text-2xl font-bold mb-4">
+        「{subject}」のボルダ集計ランキング
+      </h1>
+      <h3 className="text-lg mb-4">スコアは毎日0時に更新されます</h3>
       <AverageItemRankList subject={subject} />
     </div>
   );

--- a/components/component/trends/AverageItemRankListClient.tsx
+++ b/components/component/trends/AverageItemRankListClient.tsx
@@ -1,62 +1,39 @@
 // components/component/trends/AverageItemRankListClient.tsx
-"use client"
+"use client";
 
-import { useState } from "react"
-import useSWR from "swr"
-import { supabase } from "@/lib/supabaseClient"
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
-import RankingItem from "./RankingItem"
+import { useState } from "react";
+import { useBordaItemRank } from "@/components/hooks/useTrends"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import RankingItem from "./RankingItem";
 
-/** 平均順位の型 */
+/** ボルダスコアの型 */
 export interface AverageRank {
-  itemName: string
-  avgRank: number
-  count: number
-  calculationDate: string
+  itemName: string;
+  avgRank: number;      // ボルダスコアを格納
+  count: number;        // 出現回数
+  calculationDate: string;
 }
 
 interface AverageItemRankListClientProps {
-  subject: string
+  subject: string;
 }
 
-/**
- * クライアントコンポーネント
- * useSWR で平均順位データを取得し、タブ切り替え UI を提供します。
- */
-export default function AverageItemRankListClient({ subject }: AverageItemRankListClientProps) {
+export default function AverageItemRankListClient({ subject }: { subject: string }) {
   const [tab, setTab] = useState<"ranking" | "comments">("ranking")
-
-  const key = ["average-item-rank", subject] as const
-  const fetcher = async (): Promise<AverageRank[]> => {
-    const { data, error } = await supabase
-      .from("AverageItemRank")
-      .select("itemName,avgRank,count,calculationDate")
-      .eq("subject", subject)
-      .order("avgRank", { ascending: true })
-      .limit(10)
-    if (error) throw error
-    return data
-  }
-
-  const { data, error, isLoading } = useSWR<AverageRank[]>(key, fetcher)
-  const averageRanks = data ?? []
-
+  const { averageRanks, isLoading, isError } = useBordaItemRank(subject)
+ 
   const dummyComments = [
     { user: "ユーザーA", text: "この集計、とても参考になります！" },
-    { user: "ユーザーB", text: "Item X の順位が思ったより高い…" },
-    { user: "ユーザーC", text: "全期間での平均だけでなく、期間別も見たいです。" },
-  ]
+    { user: "ユーザーB", text: "Item X のスコアが思ったより高い…" },
+    { user: "ユーザーC", text: "全期間でのボルダスコアも見たいです。" },
+  ];
 
-  if (isLoading) return <p>Loading…</p>
-  if (error) return <p className="text-red-500">Error: {error.message}</p>
+  if (isLoading) return <p>Loading…</p>;
+  if (isError) return <p className="text-red-500">Error: {isError.message}</p>;
 
   return (
     <div className="space-y-4">
-      <Tabs
-        value={tab}
-        onValueChange={(v) => setTab(v as "ranking" | "comments")}
-        className="w-full"
-      >
+      <Tabs value={tab} onValueChange={(v) => setTab(v as "ranking" | "comments")} className="w-full">
         <TabsList className="grid grid-cols-2 mb-4 w-full">
           <TabsTrigger value="ranking">ランキング</TabsTrigger>
           <TabsTrigger value="comments">コメント</TabsTrigger>
@@ -79,5 +56,5 @@ export default function AverageItemRankListClient({ subject }: AverageItemRankLi
         </TabsContent>
       </Tabs>
     </div>
-  )
+  );
 }

--- a/components/component/trends/RankingItem.tsx
+++ b/components/component/trends/RankingItem.tsx
@@ -1,11 +1,12 @@
 // components/component/trends/RankingItem.tsx
+//AverageItemRankListClientから渡された item をそのまま描画する純粋表示コンポーネンと
 "use client";
 
 import React from "react";
 import Image from "next/image";
 import { Trophy } from "@/components/component/Icons";
 import { Card, CardContent } from "@/components/ui/card";
-import { AverageRank } from "@/components/hooks/useTrends"
+import { AverageRank } from "@/components/component/trends/AverageItemRankListClient";
 
 interface Props {
   item: AverageRank & { image?: string; description?: string; details?: Record<string,string> };
@@ -49,34 +50,22 @@ export default function RankingItem({ item, rank }: Props) {
         {/* 右側：内容 */}
         <CardContent className="flex-1 p-4">
           <div className="flex flex-col md:flex-row md:items-center gap-4">
-            {/* もしアイテムに画像があれば */}
             {item.image && (
               <div className="relative w-full md:w-24 h-24 rounded-md overflow-hidden">
-                <Image
-                  src={item.image}
-                  alt={item.itemName}
-                  fill
-                  className="object-cover"
-                />
+                <Image src={item.image} alt={item.itemName} fill className="object-cover" />
               </div>
             )}
 
             <div className="flex-1">
               <h3 className="font-bold text-lg truncate">{item.itemName}</h3>
-              {/* 説明があれば */}
               {item.description && (
-                <p className="text-sm text-muted-foreground mt-1">
-                  {item.description}
-                </p>
+                <p className="text-sm text-muted-foreground mt-1">{item.description}</p>
               )}
 
-              {/* 平均順位・登場回数などのメタ情報 */}
+              {/* ボルダスコア・登場回数 */}
               <div className="mt-2 space-y-1 text-sm text-muted-foreground">
                 <div>
-                  平均順位:{" "}
-                  <span className="font-medium">
-                    {item.avgRank.toFixed(2)}
-                  </span>
+                  スコア: <span className="font-medium">{item.avgRank.toFixed(0)}</span>
                 </div>
                 <div>
                   登場回数: <span className="font-medium">{item.count}</span>
@@ -87,7 +76,6 @@ export default function RankingItem({ item, rank }: Props) {
                 </div>
               </div>
 
-              {/* 任意の詳細があれば */}
               {item.details && (
                 <div className="mt-2 grid grid-cols-2 gap-2 text-sm">
                   {Object.entries(item.details).map(([k, v]) => (

--- a/components/hooks/useTrends.ts
+++ b/components/hooks/useTrends.ts
@@ -101,32 +101,36 @@ export function useTrendingItems(period: 'WEEKLY' | 'MONTHLY') {
   }
 }
 
-
-// --- 平均順位（全期間） ---
-export interface AverageRank {
+//ボルダスコアの型
+export interface BordaRank {
   itemName: string
-  avgRank: number
+  avgRank: number // ボルダスコア
   count: number
   calculationDate: string
 }
-export function useAverageItemRank(subject: string) {
-  const key = ['average-item-rank', subject] as const;
-  const fetcher = async (): Promise<AverageRank[]> => {
+
+// --- 平均順位(ボルダスコア順)（全期間） ---
+export function useBordaItemRank(subject: string) {
+  const key = ['borda-item-rank', subject] as const
+
+  const fetcher = async (): Promise<BordaRank[]> => {
     const { data, error } = await supabase
       .from('AverageItemRank')
       .select('itemName,avgRank,count,calculationDate')
       .eq('subject', subject)
-      .order('avgRank', { ascending: true })
-      .limit(10);
+      // ボルダスコアを降順にソート
+      .order('avgRank', { ascending: false })
+      .limit(10)
 
-    if (error) throw error;
-    return data;
-  };
+    if (error) throw error
+    return data
+  }
 
-  const { data, error } = useSWR<AverageRank[]>(key, fetcher);
+  const { data, error } = useSWR<BordaRank[]>(key, fetcher)
+
   return {
     averageRanks: data ?? [],
     isLoading: !error && !data,
     isError: error,
-  };
+  }
 }


### PR DESCRIPTION
- **名称**: `get_average_item_rank(period TEXT, subject TEXT)`
- **役割**: 指定期間（`WEEKLY`/`MONTHLY`/`DAILY`）に対し、与えられたテーマ(subject)をボルダカウント法

ロジック：Borda ポイント ＝ (リスト内アイテム数) − (そのアイテムの順位) ＋ 1として

- アイテムごとの平均順位(`averagerank`) と出現回数(`appearances`)を計算
- 上位10件を返す