### PR TITLE
ホームの画像表示修正

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { jaJP } from '@clerk/localizations';
 import { Toaster } from "@/components/ui/toaster";
 import { getCurrentLoginUserData } from "@/lib/data/userQueries";
+import { generateImageUrl } from "@/lib/utils/storage";
 import { KeepAlivePing } from "@/components/KeepAlivePing";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -26,8 +27,17 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   const { userId: clerkId } = await auth();
-  const currentLoginUserData = clerkId
+  const raw = clerkId
     ? await getCurrentLoginUserData(clerkId)
+    : null;
+
+  // ストレージパスを署名付きURLに変換
+  const currentLoginUserData = raw
+    ? {
+        ...raw,
+        image: await generateImageUrl(raw.image),
+        coverImageUrl: await generateImageUrl(raw.coverImageUrl),
+      }
     : null;
 
   return (
@@ -39,8 +49,8 @@ export default async function RootLayout({
           publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY!}
           proxyUrl={process.env.NEXT_PUBLIC_CLERK_PROXY_URL!}
         >
-        <KeepAlivePing />
-          <Header />
+          <KeepAlivePing />
+          <Header currentLoginUserData={currentLoginUserData} />
           <div className="flex-1 grid grid-cols-1 md:grid-cols-[auto_1fr] lg:grid-cols-[auto_1fr_auto] w-full max-w-7xl mx-auto">
             <aside className="hidden md:block md:w-[240px] lg:w-[260px] p-4 md:p-6 sticky top-16 self-start">
               <LeftSidebar currentLoginUserData={currentLoginUserData} />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,38 +1,32 @@
 // app/page.tsx
 import MainContentForHome from "@/components/component/layouts/MainContentForHome";
 import { getCurrentLoginUserData } from "@/lib/data/userQueries";
-import { getHomeFeed } from "@/lib/data/feedQueries";
 import { auth } from "@clerk/nextjs/server";
 import { notFound, redirect } from "next/navigation";
-import type { FeedItemWithRelations } from "@/lib/types";
+import { generateImageUrl } from "@/lib/utils/storage";
+import type { UserSnippet } from "@/lib/types";
 
 export default async function Home() {
   const { userId: clerkId } = await auth();
-  if (!clerkId) {
-    redirect("/sign-in");
-  }
+  if (!clerkId) redirect("/sign-in");
 
-  const currentLoginUserData = await getCurrentLoginUserData(clerkId);
-  if (!currentLoginUserData?.id || !currentLoginUserData?.username) {
+  // ログインユーザーのDB情報
+  const rawUserData = await getCurrentLoginUserData(clerkId);
+  if (!rawUserData?.id || !rawUserData?.username) {
     console.error("ログインユーザーのDB情報が見つかりません。");
     notFound();
   }
-  const userDbId = currentLoginUserData.id;
 
-  const initialLimit = 20;
-  let initialFeedItems: FeedItemWithRelations[] = [];
-  let initialNextCursor: string | null = null;
-  try {
-    const feedData = await getHomeFeed({ userId: userDbId, limit: initialLimit, cursor: undefined });
-    initialFeedItems = feedData.items;
-    initialNextCursor = feedData.nextCursor;
-  } catch (error) { /* ... */ }
+  // 署名付きURLに変換
+  const image = await generateImageUrl(rawUserData.image);
+  const coverImageUrl = await generateImageUrl(rawUserData.coverImageUrl);
+  const currentLoginUserData: UserSnippet & { coverImageUrl: string | null } = {
+    ...rawUserData,
+    image,
+    coverImageUrl,
+  };
 
   return (
-    <MainContentForHome
-      initialFeedItems={initialFeedItems}
-      initialNextCursor={initialNextCursor}
-      loggedInUserDbId={userDbId}
-    />
+    <MainContentForHome currentLoginUserData={currentLoginUserData} />
   );
 }

--- a/components/component/feeds/TimelineFeed.tsx
+++ b/components/component/feeds/TimelineFeed.tsx
@@ -8,12 +8,11 @@ import RankingUpdateCard from "./cards/RankingUpdateCard";
 import RetweetCard from "./cards/RetweetCard";
 import QuoteRetweetCard from "./cards/QuoteRetweetCard";
 import { getPaginatedFeedAction } from '@/lib/actions/feedActions';
-import { FeedKey } from '@/lib/types'; // FeedKey をインポート
+import { FeedKey } from '@/lib/types';
 import { FeedType } from "@prisma/client";
 import { Loader2 } from "@/components/component/Icons";
-import { useInfiniteScroll } from "@/components/hooks/useInfiniteScroll"; // パスを確認
+import { useInfiniteScroll } from "@/components/hooks/useInfiniteScroll";
 
-// Props 定義
 interface TimelineFeedProps {
   feedType: 'home' | 'profile';
   loggedInUserDbId: string | null;
@@ -108,7 +107,6 @@ export default function TimelineFeed({
             <p className='text-gray-500 text-sm'>これ以上ありません</p>
           )}
       </div>
-      {/* エンプティステート */}
       {/* ★ feedItems が空配列で、かつ終端に達している場合 ★ */}
       {feedItems && feedItems.length === 0 && !isLoadingMore && !isValidating && isReachingEnd && (
           <p className='text-center text-gray-500 py-4'>

--- a/components/component/layouts/Header.tsx
+++ b/components/component/layouts/Header.tsx
@@ -4,9 +4,19 @@
 import Link from "next/link";
 import SearchForm from "../search/SearchForm";
 import { LogInIcon,ChatBubbleIcon } from "../Icons";
-import { ClerkLoading, SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
+import { ClerkLoading, SignedIn, SignedOut } from "@clerk/nextjs";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 
-export default function Header() {
+interface HeaderProps {
+  currentLoginUserData: {
+    id: string;
+    username: string | null;
+    image: string | null;   // 署名付きURLを含むフルURL
+  } | null;
+}
+
+
+export default function Header({currentLoginUserData}: HeaderProps) {
   return (
     <header className="bg-background shadow-md px-4 md:px-6 py-3 flex items-center justify-between gap-4">
       {/* ロゴ (左端) */}
@@ -37,7 +47,17 @@ export default function Header() {
             <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
           </ClerkLoading>
           <SignedIn>
-            <UserButton />
+                    {currentLoginUserData ? (
+           <Avatar className="w-8 h-8 border">
+             <AvatarImage
+               src={currentLoginUserData.image ?? undefined}
+               alt={`${currentLoginUserData.username} のアイコン`}
+             />
+             <AvatarFallback>
+               {currentLoginUserData.username?.slice(0, 2).toUpperCase()}
+             </AvatarFallback>
+           </Avatar>
+         ) : null}
           </SignedIn>
           <SignedOut>
             <Link

--- a/components/component/layouts/LeftSidebar.tsx
+++ b/components/component/layouts/LeftSidebar.tsx
@@ -1,10 +1,11 @@
 // components/component/layouts/LeftSidebar.tsx
+// // デスクトップ表示用のクラス (モバイルでは非表示)
 import Link from "next/link";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { UserSnippet } from "@/lib/types";
 
 import {
   HomeIcon,
-  SearchIcon,
   TrendingUpIcon,
   BellIcon,
   CrownIcon,
@@ -14,14 +15,8 @@ import {
   ChatBubbleIcon
 } from "../Icons";
 
-interface UserData {
-  id: string;
-  username: string | null;
-  image: string | null;
-}
-
 interface LeftSidebarProps {
-  currentLoginUserData: UserData | null;
+  currentLoginUserData: UserSnippet | null;
 }
 
 const navItems = [
@@ -44,7 +39,6 @@ const navItems = [
 export default function LeftSidebar({
   currentLoginUserData,
 }: LeftSidebarProps) {
-  // デスクトップ表示用のクラス (モバイルでは非表示)
   const desktopClasses = "hidden md:flex flex-col";
 
   return (
@@ -53,15 +47,21 @@ export default function LeftSidebar({
         <Avatar className="w-12 h-12 border">
           <AvatarImage src={currentLoginUserData?.image ?? undefined} />
           <AvatarFallback>
-            {currentLoginUserData?.username?.charAt(0)}
+            {currentLoginUserData?.username?.charAt(0).toUpperCase()}
           </AvatarFallback>
         </Avatar>
         <div>
           <h3 className="text-lg font-bold">
-            {currentLoginUserData?.username ?? 'User'}
+            {currentLoginUserData?.name ?? "User"}
           </h3>
+          {currentLoginUserData?.username && (
+            <p className="text-sm text-muted-foreground">
+              @{currentLoginUserData.username}
+            </p>
+          )}
         </div>
       </div>
+
       <nav className="flex-grow">
         <ul className="space-y-1">
           {navItems.map(({ icon: Icon, label, href }) => (
@@ -85,7 +85,12 @@ export default function LeftSidebar({
       </nav>
 
       <div className="mt-auto pt-4 border-t">
-                <Link href="https://docs.google.com/forms/d/e/1FAIpQLSdLbVn1Wwbzfa9Zdq6ZjAnrrRMzur-ZKhu4-EXrmT8Q8__p0g/viewform" className="block" target="_blank" rel="noopener noreferrer">
+        <Link
+          href="https://docs.google.com/forms/d/e/1FAIpQLSdLbVn1Wwbzfa9Zdq6ZjAnrrRMzur-ZKhu4-EXrmT8Q8__p0g/viewform"
+          className="block"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <div className="flex items-center gap-3 px-3 py-2.5 rounded-md text-foreground/80 hover:bg-muted hover:text-foreground transition-colors">
             <ChatBubbleIcon className="h-5 w-5" />
             <span className="font-medium">ご意見</span>

--- a/components/component/layouts/MainContentForHome.tsx
+++ b/components/component/layouts/MainContentForHome.tsx
@@ -1,28 +1,24 @@
+// components/component/layouts/MainContentForHome.tsx
 import PostForm from "../posts/PostForm";
 import TimelineFeed from "../feeds/TimelineFeed";
-import type { FeedItemWithRelations } from '@/lib/types'; // FeedItemWithRelations 型をインポート
+import type { UserSnippet } from "@/lib/types";
 
 interface MainContentForHomeProps {
-  initialFeedItems: FeedItemWithRelations[];
-  initialNextCursor: string | null;
-  loggedInUserDbId: string | null; // ログインユーザーのDB IDを渡す
+  currentLoginUserData: UserSnippet;
 }
 
 export default function MainContentForHome({
-  initialFeedItems,
-  initialNextCursor,
-  loggedInUserDbId, // ログインユーザーのDB IDを渡す
+  currentLoginUserData,
 }: MainContentForHomeProps) {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 flex flex-col h-full">
       <div className="mb-3 flex-shrink-0">
-        <PostForm /> {/* PostForm をここに配置 */}
+        <PostForm currentLoginUserData={currentLoginUserData} />
       </div>
       <div className="flex-1 overflow-y-auto">
         <TimelineFeed
-        feedType="home"
-        loggedInUserDbId={loggedInUserDbId}
-        // feedType: "home"）の場合targetUserId は使わない
+          feedType="home"
+          loggedInUserDbId={currentLoginUserData.id}
         />
       </div>
     </div>

--- a/components/component/posts/PostForm.tsx
+++ b/components/component/posts/PostForm.tsx
@@ -1,19 +1,21 @@
-//co
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useRef, useState, useTransition } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { createPostAction } from "@/lib/actions/postActions";
-import { useUser } from "@clerk/nextjs";
 import { useToast } from "@/components/hooks/use-toast";
 import { Loader2, ImagePlus, XIcon } from "@/components/component/Icons";
 import { useImageUploader } from "@/components/hooks/useImageUploader";
 import Image from "next/image";
+import type { UserSnippet } from "@/lib/types";
 
-export default function PostForm() {
-  const { user, isLoaded } = useUser();
+interface PostFormProps {
+  currentLoginUserData: UserSnippet;
+}
+
+export default function PostForm({ currentLoginUserData }: PostFormProps) {
   const { toast } = useToast();
   const formRef = useRef<HTMLFormElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -54,23 +56,11 @@ export default function PostForm() {
     }
   };
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     const trimmedContent = content.trim();
-    if (trimmedContent.length === 0 && !selectedFile) {
-      toast({
-        title: "投稿エラー",
-        description: "内容を入力するか画像を選択してください。",
-        variant: "destructive",
-      });
-      return;
-    }
-    if (trimmedContent.length > 280) {
-      toast({
-        title: "投稿エラー",
-        description: "投稿内容は280文字以内で入力してください。",
-        variant: "destructive",
-      });
+    if (!trimmedContent && !selectedFile) {
+      toast({ title: "投稿エラー", description: "内容を入力するか画像を選択してください。", variant: "destructive" });
       return;
     }
 
@@ -78,123 +68,57 @@ export default function PostForm() {
       try {
         let imageUrl: string | null = null;
         if (selectedFile) {
-          const uploaded = await uploadImage(selectedFile);
-          if (!uploaded) {
-            return;
-          }
-          imageUrl = uploaded.signedUrl;
+          const res = await uploadImage(selectedFile);
+          if (!res) return;
+          imageUrl = res.signedUrl;
         }
 
-        const result = await createPostAction({
-          content: trimmedContent,
-          imageUrl,
-        });
-
+        const result = await createPostAction({ content: trimmedContent, imageUrl });
         if (result.success) {
-          setContent("");
-          setSelectedFile(null);
-          setPreviewUrl(null);
+          setContent(""); setSelectedFile(null); setPreviewUrl(null);
           if (fileInputRef.current) fileInputRef.current.value = "";
           toast({ title: result.message || "投稿しました！" });
         } else {
-          toast({
-            title: "投稿エラー",
-            description: result.error,
-            variant: "destructive",
-          });
+          toast({ title: "投稿エラー", description: result.error, variant: "destructive" });
         }
-      } catch (error) {
-        console.error("Error submitting post:", error);
-        toast({
-          title: "投稿エラー",
-          description: "予期せぬエラーが発生しました。",
-          variant: "destructive",
-        });
+      } catch {
+        toast({ title: "投稿エラー", description: "予期せぬエラーが発生しました。", variant: "destructive" });
       }
     });
   };
 
-  if (!isLoaded)
-    return (
-      <div className="p-4">
-        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-      </div>
-    );
-  if (!user)
-    return (
-      <div className="p-4 text-center text-muted-foreground">
-        投稿するにはログインしてください。
-      </div>
-    );
-
-  const isSubmitDisabled =
-    isPending || isUploading || (content.trim().length === 0 && !selectedFile);
+  const isSubmitDisabled = isPending || isUploading || (!content.trim() && !selectedFile);
 
   return (
     <div className="flex space-x-4 p-4 border-b">
-      <Avatar>
-        <AvatarImage src={user.imageUrl} alt={user.username || undefined} />
-        <AvatarFallback>{user.username?.charAt(0).toUpperCase() || "?"}</AvatarFallback>
+      <Avatar className="w-12 h-12">
+        <AvatarImage src={currentLoginUserData.image ?? undefined} alt={currentLoginUserData.username ?? undefined} />
+        <AvatarFallback>{currentLoginUserData.username?.charAt(0).toUpperCase() ?? "?"}</AvatarFallback>
       </Avatar>
       <form ref={formRef} onSubmit={handleSubmit} className="flex-1 space-y-2">
         <Textarea
-          name="content"
           placeholder="投稿してみよう"
           rows={3}
           maxLength={280}
-          className="w-full resize-none border-none focus-visible:ring-0 focus-visible:ring-offset-0 bg-transparent"
           disabled={isPending || isUploading}
           value={content}
           onChange={(e) => setContent(e.target.value)}
         />
-
         {previewUrl && (
           <div className="relative w-fit">
-            <Image
-              src={previewUrl}
-              alt="Preview"
-              width={100}
-              height={100}
-              className="rounded-md object-cover max-h-40 w-auto"
-            />
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="absolute top-1 right-1 h-6 w-6 bg-black/50 text-white rounded-full hover:bg-black/70"
-              onClick={handleRemoveImage}
-              disabled={isPending || isUploading}
-            >
+            <Image src={previewUrl} alt="Preview" width={100} height={100} className="rounded-md object-cover max-h-40 w-auto" />
+            <Button type="button" variant="ghost" size="icon" className="absolute top-1 right-1" onClick={handleRemoveImage} disabled={isPending || isUploading}>
               <XIcon className="h-4 w-4" />
-              <span className="sr-only">画像を削除</span>
             </Button>
           </div>
         )}
-
         <div className="flex justify-between items-center">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={isPending || isUploading || !!selectedFile}
-            title="画像を追加"
-          >
-            <ImagePlus className="h-5 w-5 text-primary" />
-            <span className="sr-only">画像を選択</span>
+          <Button type="button" variant="ghost" size="icon" onClick={() => fileInputRef.current?.click()} disabled={isPending || isUploading || !!selectedFile}>
+            <ImagePlus className="h-5 w-5" />
           </Button>
-          <input
-            type="file"
-            accept="image/*"
-            ref={fileInputRef}
-            onChange={handleFileChange}
-            className="hidden"
-            disabled={isPending || isUploading}
-          />
+          <input type="file" accept="image/*" ref={fileInputRef} onChange={handleFileChange} className="hidden" disabled={isPending || isUploading} />
           <Button type="submit" disabled={isSubmitDisabled} size="sm">
-            {isPending || isUploading ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : null}
+            {isPending || isUploading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
             {isPending || isUploading ? "処理中..." : "投稿する"}
           </Button>
         </div>

--- a/components/component/rankings/CommentSection.tsx
+++ b/components/component/rankings/CommentSection.tsx
@@ -45,7 +45,6 @@ export default function CommentSection({ listId }: Props) {
         {comments.map((c) => (
           <div key={c.id} className="p-3 bg-gray-50 rounded">
             <div className="flex items-center mb-1">
-              {/* 後でユーザー情報を紐付けるならここに表示 */}
               <strong>{c.userId}</strong>
               <span className="ml-auto text-xs text-muted-foreground">
                 {new Date(c.createdAt).toLocaleString()}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,8 +7,6 @@ export type ListStatus = "DRAFT" | "PUBLISHED";
 export type FeedType = "POST" | "RANKING_UPDATE" | "RETWEET" | "QUOTE_RETWEET";
 
 
-
-
 export type TrendPeriod =
   "WEEKLY" | "MONTHLY";
 


### PR DESCRIPTION
ホーム画面の画像表示をプロフィール写真に変更

app/page.tsx

initialFeedItems／initialNextCursor の取得と渡しを削除

サーバー側ではログインユーザー情報だけ取得し、generateImageUrl で画像パスを署名付きURLに変換

MainContentForHome には currentLoginUserData のみ渡すよう変更

MainContentForHome.tsx

Props から initialFeedItems／initialNextCursor を削除

TimelineFeed は feedType="home" と loggedInUserDbId のみ受け取り

TimelineFeed.tsx

fallbackData 設定を外し、最初のページもクライアントサイドの無限スクロールで取得

PostForm.tsx

useUser ではなく、currentLoginUserData.image を <AvatarImage> の src に使用

投稿フォーム内でも最新のプロフィール写真を表示