### PR TITLE
画像差し替え時の前の画持を削除

### DIFF
--- a/components/component/rankings/NewRankingForm.tsx
+++ b/components/component/rankings/NewRankingForm.tsx
@@ -171,7 +171,7 @@ export function NewRankingForm() {
       try {
         itemsData = await Promise.all(
           editableItems.map(async (item) => {
-            let finalUrl = item.imageUrl ?? null;
+            let finalUrl = item.imagePath ?? null;
             if (item.imageFile) {
               const uploaded = await uploadImage(item.imageFile);
               if (!uploaded) throw new Error("画像アップロードに失敗しました。");


### PR DESCRIPTION
既存の imageUrl（ストレージキー）をそのまま保持 し、プレビュー用のサイン済み URL は別フィールド previewUrl として追加

EditableRankedItem コンポーネントでは、表示は previewUrl、内部のデータ送信は imagePath（オリジナルのキー文字列）で扱うように変更

フォーム送信時（NewRankingForm.tsx）は、item.imagePath を参照して既存画像を扱い、新規アップロード時は uploaded.path を imageUrl（送信用）にセット

サーバーアクション（saveRankingListItemsAction）で、更新前のパスを oldPaths、送られてきた imagePath／imageUrl を newPaths として比較し、差分だけ supabaseAdmin.storage.remove() で削除

これにより、プレビュー表示とサーバー側のファイル削除ロジックの両方で「キー文字列」と「プレビュー URL」を混同せずに扱えるように統一